### PR TITLE
Add table of contents deletion

### DIFF
--- a/src/Mdfmt/Options/CommandLineOptions.cs
+++ b/src/Mdfmt/Options/CommandLineOptions.cs
@@ -16,7 +16,7 @@ public class CommandLineOptions
     [Value(0, Default = ".", HelpText = "The directory in which to process .md files, or a specific .md file.")]
     public string Path { get; set; }
 
-    [Option("minimum-entry-count", Default = 2, HelpText = "The minimum number of entries for which TOC is generated.")]
+    [Option("minimum-entry-count", Default = 2, HelpText = "The minimum number of entries for which TOC is generated.  0 means never generate TOC.")]
     public int MinimumEntryCount { get; set; }
 
     [Option("newline-strategy", Default = NewlineStrategy.PreferWindows, HelpText = "One of Unix, Windows, PreferUnix, PreferWindows.  Preferred options respect the file and take effect only if the file has a mixture.")]

--- a/src/Mdfmt/Properties/launchSettings.json
+++ b/src/Mdfmt/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Mdfmt": {
-      "commandName": "Project",
-      "commandLineArgs": "D:\\mdfmt-private\\TODO.md -p vscode"
+      "commandName": "Project"
     }
   }
 }

--- a/src/Mdfmt/Updater.cs
+++ b/src/Mdfmt/Updater.cs
@@ -33,31 +33,36 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
         // Generate a TOC based on headings.
         Toc newToc = _tocGenerator.GenerateToc(_md.FileName, _md.HeadingRegions, _md.Newline);
 
-        // If the TOC is too small, get out.
-        if (newToc.EntryCount < _minimumEntryCount)
-        {
-            return;
-        }
+        // Is the desired end state to have a TOC with the content of newToc in the document?
+        bool tocShouldExist =
+            _minimumEntryCount > 0 &&
+            newToc.EntryCount >= _minimumEntryCount;
 
-        if (_md.HasToc)
+        if (_md.HasToc) // The document has a TOC already.
         {
-            // There is a TOC.  Update it if necessary.
-            Region tocRegion = _md.TocRegion;
-            if (tocRegion.Content != newToc.Content)
+            if (tocShouldExist)
             {
-                tocRegion.Content = newToc.Content;
-                if (_verbose)
+                Region tocRegion = _md.TocRegion;
+                if (tocRegion.Content != newToc.Content)
                 {
-                    Console.WriteLine("  Updated TOC");
+                    tocRegion.Content = newToc.Content;
+                    if (_verbose)
+                    {
+                        Console.WriteLine("  Updated TOC");
+                    }
                 }
             }
-        }
-        else
-        {
-            // There is no TOC.  If there is a first heading, insert it after that.
-            if (_md.HasHeading)
+            else
             {
-                _md.InsertTocAfterFirstHeading(newToc.Content);
+                _md.DeleteToc();
+                Console.WriteLine("  Removed TOC");
+            }
+        }
+        else // The document does not have a TOC.
+        {
+            if (tocShouldExist)
+            {
+                _md.AddToc(newToc.Content);
                 if (_verbose)
                 {
                     Console.WriteLine("  Inserted new TOC");


### PR DESCRIPTION
- Clarified that passing `--minimum-entry-count 0`  means definitely DO NOT generate TOC.
- Changes to `Mdstruct.cs`:
  - Add `DeleteToc()` method.
  - Rename `InsertTocAfterFirstHeading` to `AddToc()` and make the method idempotent.
- Upgraded `Updater.cs` so that TOC is inserted, deleted, or just left alone as appropriate, depending upon the combination of the Markdown file state and the arguments passed to the command line.
