### PR TITLE
Link updating now matches on heading or destination.

### DIFF
--- a/src/Mdfmt/Generators/Links/LinkDestinationGeneratorFactory.cs
+++ b/src/Mdfmt/Generators/Links/LinkDestinationGeneratorFactory.cs
@@ -1,5 +1,8 @@
 ﻿using Mdfmt.Options;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Mdfmt.Generators.Links;
 
@@ -13,5 +16,30 @@ public static class LinkDestinationGeneratorFactory
             Platform.Azure => new AzureLinkDestinationGenerator(),
             _ => throw new InvalidOperationException($"Unsupported {nameof(Platform)} value: {platform}"),
         };
+    }
+
+    /// <summary>
+    /// Make and return one of each concrete class that implements <c>ILinkDestinationGenerator</c>.
+    /// </summary>
+    /// <returns>List of <c>ILinkDestinationGenerator</c></returns>
+    public static List<ILinkDestinationGenerator> ManufactureOneOfEach()
+    {
+        Type interfaceType = typeof(ILinkDestinationGenerator);
+        Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        IEnumerable<Type> types = assemblies
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => interfaceType.IsAssignableFrom(type)
+                           && type.IsClass
+                           && !type.IsAbstract
+                           && type.GetConstructor(Type.EmptyTypes) != null);
+        List<ILinkDestinationGenerator> result = [];
+        foreach (var type in types)
+        {
+            if (Activator.CreateInstance(type) is ILinkDestinationGenerator instance)
+            {
+                result.Add(instance);
+            }
+        }
+        return result;
     }
 }

--- a/src/Mdfmt/Updater.cs
+++ b/src/Mdfmt/Updater.cs
@@ -77,7 +77,8 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
         {
             if (LinkWithinSameFile(linkRegion.Destination))
             {
-                if (_md.TryGetHeadingRegion(linkRegion.Label, out HeadingRegion headingRegion))
+                if (_md.TryGetHeadingRegion(linkRegion.Label, out HeadingRegion headingRegion) ||
+                    _md.TryGetHeadingRegion(linkRegion.Destination, out headingRegion))
                 {
                     string destination = _linkDestinationGenerator.GenerateLinkDestination(_md.FileName, headingRegion.HeadingText);
                     if (linkRegion.Destination != destination)
@@ -85,7 +86,7 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
                         linkRegion.Destination = destination;
                         if (_verbose)
                         {
-                            Console.WriteLine("  Updated link");
+                            Console.WriteLine($"  Updated link with label [{linkRegion.Label}] to target destination ({linkRegion.Destination})");
                         }
                     }
                 }
@@ -93,7 +94,7 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
                 {
                     if (_verbose)
                     {
-                        Console.WriteLine($"  Could not find heading to match label {linkRegion.Label}");
+                        Console.WriteLine($"  Could not match link to heading: {linkRegion.Content}");
                     }
                 }
             }


### PR DESCRIPTION
- `Updater.UpdateLinks()` updated to find links to update based on link label or link destination.  This covers many more cases and it sets the stage for automatic section numbering, since now, once a link is working, it will not break if the heading text changes.
- Part of this change is that the dictionary for heading lookup in `MdStruct` is now keyed not only on heading text, but also on link destination of all the ways Mdfmt formats link destinations.