### PR TITLE
Implemented automatic section numbering

### DIFF
--- a/src/Mdfmt/Constants.cs
+++ b/src/Mdfmt/Constants.cs
@@ -17,4 +17,11 @@ public static class Constants
     /// </summary>
     // For correct splitting behavior, keep longer strings before shorter ones.
     public static readonly string[] AllNewlines = [WindowsNewline, UnixNewline];
+
+    /// <summary>
+    /// The maximum number of '#' symbols that can occur at the front of a Markdown heading.  If
+    /// there are more than this many, then the content is regarded as just plain content region
+    /// and not as a heading.
+    /// </summary>
+    public const int MaximumHeadingNumberSignCount = 6;
 }

--- a/src/Mdfmt/Model/CompositeRegion.cs
+++ b/src/Mdfmt/Model/CompositeRegion.cs
@@ -14,7 +14,7 @@ public abstract class CompositeRegion(IReadOnlyList<AtomicRegion> atomicRegions)
     /// <summary>
     /// List of atomic regions that make up this composite region.  Backing storage for <c>Content</c> property.
     /// </summary>
-    private readonly IReadOnlyList<AtomicRegion> _atomicRegions = atomicRegions;
+    protected readonly IReadOnlyList<AtomicRegion> _atomicRegions = atomicRegions;
 
     /// <inheritdoc/>
     public override string Content

--- a/src/Mdfmt/Model/HeadingRegion.cs
+++ b/src/Mdfmt/Model/HeadingRegion.cs
@@ -1,11 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Mdfmt.Model;
 
 public class HeadingRegion(IReadOnlyList<AtomicRegion> atomicRegions) : CompositeRegion(atomicRegions)
 {
+    private static readonly Regex HeadingNumberRegex = new(@"^(?<headingStart>\s*#+ )(?:(?<headingNumber>\d+(?:\.\d+)*\.?) )?(?<rest>.*)", RegexOptions.Compiled);
+    private const string HeadingStartGroup = "headingStart";
+    private const string HeadingNumberGroup = "headingNumber";
+    private const string RestGroup = "rest";
+
     /// <summary>
     /// The level of the heading, which is an integer one less than the number of '#' characters in
     /// the Markdown.
@@ -16,4 +22,47 @@ public class HeadingRegion(IReadOnlyList<AtomicRegion> atomicRegions) : Composit
     /// Heading text in rendered Markdown document
     /// </summary>
     public string HeadingText => ActiveContent.TrimStart().TrimStart('#').Trim();
+
+
+    /// <summary>
+    /// Get the first content region of the heading.
+    /// </summary>
+    /// <returns>The first content region of the heading.</returns>
+    public ContentRegion FirstContentRegion()
+    {
+        return (ContentRegion) _atomicRegions.First(r => r is ContentRegion);
+    }
+
+    /// <summary>
+    /// Idempotently set the heading number to the value specified.  If you want to remove a
+    /// heading number, then set the value null or empty.
+    /// </summary>
+    public string HeadingNumber
+    {
+        set
+        {
+            UpdateHeadingNumber(value);
+        }
+    }
+
+    private void UpdateHeadingNumber(string headingNumber)
+    {
+        ContentRegion contentRegion = FirstContentRegion();
+        string content = contentRegion.Content;
+        Match match = HeadingNumberRegex.Match(content);
+        if (match.Success)
+        {
+            string headingStart = match.Groups[HeadingStartGroup].Value;
+            string rest = match.Groups[RestGroup].Value;
+            if (string.IsNullOrEmpty(headingNumber))
+            {
+                contentRegion.Content = $"{headingStart}{rest}";
+            }
+            else
+            {
+                contentRegion.Content = $"{headingStart}{headingNumber.Trim()} {rest}";
+            }
+        }
+    }
+
 }

--- a/src/Mdfmt/Model/MdStruct.cs
+++ b/src/Mdfmt/Model/MdStruct.cs
@@ -23,40 +23,27 @@ namespace Mdfmt.Model;
 /// <param name="newlineRegion">
 /// The newline region being used in this file.
 /// </param>
-public class MdStruct
-{
-    public MdStruct(
-        string filePath,
-        List<Region> regions,
-        bool isModified,
-        NewlineRegion newlineRegion
+public class MdStruct(
+    string filePath,
+    List<Region> regions,
+    bool isModified,
+    NewlineRegion newlineRegion
     )
-    {
-        FilePath = filePath;
-        FileName = Path.GetFileName(filePath);
-        _regions = regions;
-        _isModified = isModified;
-        _newlineRegion = newlineRegion;
-        LinkRegions = new RegionEnumerable<LinkRegion>(regions);
-        TocRegions = new RegionEnumerable<TocRegion>(regions);
-        HeadingRegions = new RegionEnumerable<HeadingRegion>(regions);
-        _headingRegionDictionary = MakeHeadingRegionDictionary();
-    }
-
+{
     /// <summary>
     /// Path of Markdown file from which this data structure was loaded.
     /// </summary>
-    public string FilePath { get; }
+    public string FilePath { get; } = filePath;
 
     /// <summary>
     /// Simple file name of the Markdown file, without any path information.
     /// </summary>
-    public string FileName { get; }
+    public string FileName { get; } = Path.GetFileName(filePath);
 
     /// <summary>
     /// Regions of the Markdown file.
     /// </summary>
-    private readonly List<Region> _regions;
+    private readonly List<Region> _regions = regions;
 
     /// <summary>
     /// <para>
@@ -76,7 +63,7 @@ public class MdStruct
     /// as inserting new regions.
     /// </para>
     /// </summary>
-    private bool _isModified;
+    private bool _isModified = isModified;
 
     /// <summary>
     /// Whether this data structure has been modified since it was loaded.
@@ -86,7 +73,7 @@ public class MdStruct
     /// <summary>
     /// The newline region being used in this file.
     /// </summary>
-    private readonly NewlineRegion _newlineRegion;
+    private readonly NewlineRegion _newlineRegion = newlineRegion;
 
     /// <summary>
     /// String containing the newline character or sequence being used for line termination.
@@ -106,7 +93,7 @@ public class MdStruct
     /// <summary>
     /// Enumerate the regions of type <c>LinkRegion</c>.
     /// </summary>
-    public IEnumerable<LinkRegion> LinkRegions { get; }
+    public IEnumerable<LinkRegion> LinkRegions { get; } = new RegionEnumerable<LinkRegion>(regions);
 
     /// <summary>
     /// The number of link regions.
@@ -121,7 +108,7 @@ public class MdStruct
     /// <summary>
     /// Enumerate the regions of type <c>HeadingRegion</c>.
     /// </summary>
-    public IEnumerable<HeadingRegion> HeadingRegions { get; }
+    public IEnumerable<HeadingRegion> HeadingRegions { get; } = new RegionEnumerable<HeadingRegion>(regions);
 
     /// <summary>
     /// The number of heading regions.
@@ -136,7 +123,7 @@ public class MdStruct
     /// <summary>
     /// Enumerate the regions of type <c>TocRegion</c>.
     /// </summary>
-    public IEnumerable<TocRegion> TocRegions { get; }
+    public IEnumerable<TocRegion> TocRegions { get; } = new RegionEnumerable<TocRegion>(regions);
 
     /// <summary>
     /// The table of contents of this document or null if none.  (If there is more than one
@@ -227,22 +214,11 @@ public class MdStruct
 
     /// <summary>
     /// <para>
-    /// Dictionary for finding instances of <c>HeadingRegion</c>, keyed on both heading text and on
-    /// link destinations that can target each heading.  Heading text is the text a human reads in
-    /// the rendered Markdown document.  Link destinations that are supported include all the in-
+    /// Make and return a new dictionary for finding instances of <c>HeadingRegion</c>, keyed on
+    /// both heading text and on link destinations that can target each heading, based on the
+    /// state of the headings in this MdStruct.  Heading text is the text a human reads in the
+    /// rendered Markdown document.  Link destinations that are supported include all the in
     /// document link formats that Mdfmt supports.
-    /// supports.
-    /// </para>
-    /// </summary>
-    private readonly Dictionary<string, HeadingRegion> _headingRegionDictionary;
-
-    /// <summary>
-    /// <para>
-    /// Dictionary for finding instances of <c>HeadingRegion</c>, keyed on both heading text and on
-    /// link destinations that can target each heading.  Heading text is the text a human reads in
-    /// the rendered Markdown document.  Link destinations that are supported include all the in-
-    /// document link formats that Mdfmt supports.
-    /// supports.
     /// </para>
     /// <para>
     /// Note: When a document contains multiple headings that all have the same text, none of these
@@ -251,11 +227,10 @@ public class MdStruct
     /// no harm" sort of approach.
     /// </para>
     /// </summary>
-    /// <param name="regions">Regions of a Markdown file, including the headings</param>
     /// <returns>
-    /// Dictionary for looking up heading regions by headign text and by link destination.
+    /// Dictionary for looking up heading regions by heading text and by link destination.
     /// </returns>
-    private Dictionary<string, HeadingRegion> MakeHeadingRegionDictionary()
+    public Dictionary<string, HeadingRegion> MakeHeadingRegionDictionary()
     {
         // The goal is to build and return this.
         Dictionary<string, HeadingRegion> headingRegions = [];
@@ -298,22 +273,4 @@ public class MdStruct
 
         return headingRegions;
     }
-
-    /// <summary>
-    /// Try to find a <c>HeadingRegion</c> based on lookup by heading text or link destination
-    /// targeting the heading.
-    /// </summary>
-    /// <param name="key">
-    /// A key that is either the text of the heading as it appears in a rendered Markdown document
-    /// or the destination of a link that is targeting the heading.
-    /// </param>
-    /// <param name="headingRegion">
-    /// Output parameter that returns the <c>&lt;HeadingRegion&gt;</c> when found.
-    /// </param>
-    /// <returns>
-    /// <c>bool</c> indicating whether <c>HeadingRegion</c> was found.  See also the parameter,
-    /// <c>out HeadingRegion headingRegion</c>.
-    /// </returns>
-    public bool TryGetHeadingRegion(string key, out HeadingRegion headingRegion) =>
-        _headingRegionDictionary.TryGetValue(key, out headingRegion);
 }

--- a/src/Mdfmt/Model/RegionIEnumerableExtensions.cs
+++ b/src/Mdfmt/Model/RegionIEnumerableExtensions.cs
@@ -34,6 +34,15 @@ public static class RegionIEnumerableExtensions
 
     public static bool IsHeading(this IEnumerable<Region> list)
     {
-        return string.Concat(list.Select(r => r.ActiveContent)).TrimStart().StartsWith('#');
+        // If the active content, when trimmed, starts with from 1 to 6 '#' characters, then it is a heading.
+        string headingText = string.Concat(list.Select(r => r.ActiveContent)).TrimStart();
+        int i = 0;
+        int numberSignCount = 0;
+        while (i < headingText.Length && headingText[i] == '#')
+        {
+            numberSignCount++;
+            i++;
+        }
+        return numberSignCount > 0  && numberSignCount <= Constants.MaximumHeadingNumberSignCount;
     }
 }

--- a/src/Mdfmt/Options/CommandLineOptions.cs
+++ b/src/Mdfmt/Options/CommandLineOptions.cs
@@ -4,8 +4,11 @@ namespace Mdfmt.Options;
 
 public class CommandLineOptions
 {
-    [Option('p', "platform", Default = Platform.Azure, HelpText = "Target platform for Markdown formatting.  One of: Azure, VsCode")]
+    [Option('p', "platform", Default = Platform.Azure, HelpText = "Target platform for Markdown formatting.  One of: [Azure, VsCode].")]
     public Platform Platform { get; set; }
+
+    [Option('n', "heading-numbers", Default = "none", HelpText = "Whether to include heading numbers.  One of: [none, 1., 1].  Use 1. or 1 to include heading numbers. The name of the \"1\" options indicates whether generated numbers will end in a period.")]
+    public string HeadingNumbering { get; set; }
 
     [Option('r', "recursive", Default = false, HelpText = "Process .md files recursively in all subfolders.")]
     public bool Recursive { get; set; }
@@ -16,9 +19,9 @@ public class CommandLineOptions
     [Value(0, Default = ".", HelpText = "The directory in which to process .md files, or a specific .md file.")]
     public string Path { get; set; }
 
-    [Option("minimum-entry-count", Default = 2, HelpText = "The minimum number of entries for which TOC is generated.  0 means never generate TOC.")]
+    [Option("minimum-entry-count", Default = 2, HelpText = "The minimum number of entries for which to include TOC.  0 turns off/removes TOC.")]
     public int MinimumEntryCount { get; set; }
 
-    [Option("newline-strategy", Default = NewlineStrategy.PreferWindows, HelpText = "One of Unix, Windows, PreferUnix, PreferWindows.  Preferred options respect the file and take effect only if the file has a mixture.")]
+    [Option("newline-strategy", Default = NewlineStrategy.PreferWindows, HelpText = "One of: [Unix, Windows, PreferUnix, PreferWindows].  Preferred options respect the file and take effect only if the file has a mixture.")]
     public NewlineStrategy NewlineStrategy { get; set; }
 }

--- a/src/Mdfmt/Options/HeadingNumbers.cs
+++ b/src/Mdfmt/Options/HeadingNumbers.cs
@@ -1,0 +1,19 @@
+﻿namespace Mdfmt.Options;
+
+public static class HeadingNumbers
+{
+    /// <summary>
+    /// String indicating that no heading numbers are desired.  Evaluate in a case-insensitive way.
+    /// </summary>
+    public const string None = "None";
+
+    /// <summary>
+    /// String indicating the desire for heading numbers that include a trailing period.
+    /// </summary>
+    public const string WithTrailingPeriod = "1.";
+
+    /// <summary>
+    /// String indicating the desire for heading numbers that do not include a trailing period.
+    /// </summary>
+    public const string WithoutTrailingPeriod = "1";
+}

--- a/src/Mdfmt/Processor.cs
+++ b/src/Mdfmt/Processor.cs
@@ -28,7 +28,7 @@ public class Processor
         _mdStructLoader = new(options.NewlineStrategy);
         _linkDestinationGenerator = LinkDestinationGeneratorFactory.Manufacture(_options.Platform);
         _tocGenerator = new(_linkDestinationGenerator);
-        _updater = new(_tocGenerator, _options.MinimumEntryCount, _linkDestinationGenerator, _options.Verbose);
+        _updater = new(_tocGenerator, _linkDestinationGenerator, _options);
     }
 
     private List<string> FindFilePathsToProcess()

--- a/src/Mdfmt/Updater.cs
+++ b/src/Mdfmt/Updater.cs
@@ -1,7 +1,10 @@
 ﻿using Mdfmt.Generators.Links;
 using Mdfmt.Generators.Tocs;
 using Mdfmt.Model;
+using Mdfmt.Options;
 using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Mdfmt;
 
@@ -9,23 +12,120 @@ namespace Mdfmt;
 /// Perform needed updates to the Regions data structure, into which the Markdown file has been loaded.
 /// </summary>
 /// <param name="tocGenerator">Table of contents generator</param>
-/// <param name="minimumEntryCount">The minimum number of entries in a Table of Contents before it will be added to a file</param>
 /// <param name="linkDestinationGenerator">Generator for link destinations, to update links in the document</param>
 /// <param name="verbose">Whether to generate extra output about what the program is doing</param>
-public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDestinationGenerator linkDestinationGenerator, bool verbose)
+public class Updater(TocGenerator tocGenerator, ILinkDestinationGenerator linkDestinationGenerator, CommandLineOptions options)
 {
     private readonly TocGenerator _tocGenerator = tocGenerator;
-    private readonly int _minimumEntryCount = minimumEntryCount;
     private readonly ILinkDestinationGenerator _linkDestinationGenerator = linkDestinationGenerator;
-    private readonly bool _verbose = verbose;
+    private readonly CommandLineOptions _options = options;
 
     private MdStruct _md;
 
     public void Update(MdStruct md)
     {
         _md = md;
+
+        // Make heading region dictionary, keyed on heading text and link destination.
+        Dictionary<string, HeadingRegion> headingRegionDictionary = _md.MakeHeadingRegionDictionary();
+
+        UpdateHeadingNumbers(); //Note: This can change headings!
+
+        // Update TOC with latest headings.
         UpdateToc();
-        UpdateLinks();
+
+        // Updated links in the body of the document.  Use the headingRegionDictionary with stale
+        // link destination keys to find current headings from the stale links in the body.
+        UpdateLinks(headingRegionDictionary);
+    }
+
+    private void UpdateHeadingNumbers()
+    {
+        if (_options.HeadingNumbering.Equals(HeadingNumbers.None, StringComparison.OrdinalIgnoreCase))
+        {
+            foreach (HeadingRegion headingRegion in _md.HeadingRegions)
+            {
+                headingRegion.HeadingNumber = "";
+            }
+        }
+        else if (
+            _options.HeadingNumbering == HeadingNumbers.WithTrailingPeriod ||
+            _options.HeadingNumbering == HeadingNumbers.WithoutTrailingPeriod)
+        {
+            // Buffer used to assign multi-level heading numbers like 1.2.3.
+            int[] counters = new int[Constants.MaximumHeadingNumberSignCount];
+
+            // String buffer used to make a heading number.
+            StringBuilder sb = new();
+
+            // Previous index into numbers, or -1 if none.
+            int prevN = -1;
+
+            foreach (HeadingRegion headingRegion in _md.HeadingRegions)
+            {
+                // Heading level.  # is level 0, ## is level 1, ### is level 2, etc.
+                int level = headingRegion.Level;
+
+                // Index into numbers where heading number counter is.  Edge case: n is -1 for heading level 0,
+                // indicating that we don't count at that level:  That's the document title.
+                int n = headingRegion.Level - 1;
+
+                // Beware of documents with too many heading levels.
+                if (n == counters.Length)
+                {
+                    Console.WriteLine($"Only {counters.Length} levels of heading numbering are supported.");
+                    // Short circuit the execution of this method, so other updaters can still run.  
+                    // To the extent that this method DID change any headings before it ran into heading
+                    // overflow, its still good to run other updaters so that they can patch up 
+                    // links to headings that changed, update the TOC, etc.
+                    return;
+                }
+
+                // Handle edge case.  We will not assign a section number to a heading with only
+                // one '#', which is typically just the title of the document.
+                if (n < 0)
+                {
+                    prevN = n;
+                    continue;
+                }
+
+                // If the previous heading was the document title, ensure all the counters are 0.
+                if (prevN == -1)
+                {
+                    Array.Fill(counters, 0);
+                }
+                else if (prevN > n)
+                {
+                    // Zero out counters for more indented sections that are fully processed.
+                    Array.Fill(counters, 0, n + 1, prevN - n);
+                }
+
+                // Up the current counter.
+                counters[n]++;
+
+                // Generate and assign heading number
+                sb.Clear();
+                for (int i = 0; i <= n; i++)
+                {
+                    if (sb.Length > 0)
+                    {
+                        sb.Append('.');
+                    }
+                    sb.Append($"{counters[i]}");
+                }
+                if (_options.HeadingNumbering == HeadingNumbers.WithTrailingPeriod)
+                    sb.Append('.');
+                headingRegion.HeadingNumber = sb.ToString();
+
+                // Set up for next iteration.  This helps us know when to zero out counters.
+                prevN = n;
+            }
+        }
+        else
+        {
+            Console.WriteLine($"Invalid choice of heading numbering: {_options.HeadingNumbering}.  Try the --help option.");
+            Environment.Exit(ExitCodes.MisuseOfCommand);
+        }
     }
 
     private void UpdateToc()
@@ -35,8 +135,8 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
 
         // Is the desired end state to have a TOC with the content of newToc in the document?
         bool tocShouldExist =
-            _minimumEntryCount > 0 &&
-            newToc.EntryCount >= _minimumEntryCount;
+            _options.MinimumEntryCount > 0 &&
+            newToc.EntryCount >= _options.MinimumEntryCount;
 
         if (_md.HasToc) // The document has a TOC already.
         {
@@ -46,7 +146,7 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
                 if (tocRegion.Content != newToc.Content)
                 {
                     tocRegion.Content = newToc.Content;
-                    if (_verbose)
+                    if (_options.Verbose)
                     {
                         Console.WriteLine("  Updated TOC");
                     }
@@ -63,7 +163,7 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
             if (tocShouldExist)
             {
                 _md.AddToc(newToc.Content);
-                if (_verbose)
+                if (_options.Verbose)
                 {
                     Console.WriteLine("  Inserted new TOC");
                 }
@@ -71,20 +171,30 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
         }
     }
 
-    private void UpdateLinks()
+    /// <summary>
+    /// Update link destinations of links that navigate within the document, to be current  for
+    /// possible changes due to heading numbering.
+    /// </summary>
+    /// <param name="headingRegionDictionary">
+    /// Heading region dictionary, keyed on original heading text and link destinations.  The link
+    /// destination keys will be stale if sections were renumbered, and they will lead to the updated
+    /// heading regions.  This is good:  It allows us to look up a stale link destination, get a
+    /// current heading region, and use the current heading to update the stale link destination.
+    /// </param>
+    private void UpdateLinks(Dictionary<string, HeadingRegion> headingRegionDictionary)
     {
         foreach (LinkRegion linkRegion in _md.LinkRegions)
         {
             if (LinkWithinSameFile(linkRegion.Destination))
             {
-                if (_md.TryGetHeadingRegion(linkRegion.Label, out HeadingRegion headingRegion) ||
-                    _md.TryGetHeadingRegion(linkRegion.Destination, out headingRegion))
+                if (headingRegionDictionary.TryGetValue(linkRegion.Label, out HeadingRegion headingRegion) ||
+                    headingRegionDictionary.TryGetValue(linkRegion.Destination, out headingRegion))
                 {
                     string destination = _linkDestinationGenerator.GenerateLinkDestination(_md.FileName, headingRegion.HeadingText);
                     if (linkRegion.Destination != destination)
                     {
                         linkRegion.Destination = destination;
-                        if (_verbose)
+                        if (_options.Verbose)
                         {
                             Console.WriteLine($"  Updated link with label [{linkRegion.Label}] to target destination ({linkRegion.Destination})");
                         }
@@ -92,7 +202,7 @@ public class Updater(TocGenerator tocGenerator, int minimumEntryCount, ILinkDest
                 }
                 else
                 {
-                    if (_verbose)
+                    if (_options.Verbose)
                     {
                         Console.WriteLine($"  Could not match link to heading: {linkRegion.Content}");
                     }


### PR DESCRIPTION
- HeadingRegion was updated with the ability to set and clear section numbers.
- In MdStruct, method MakeHeadingRegionDictionary became public.  We might want to do that more than once  (not just on construction) since headings can be changed by updaters.
- RegionEnumerableExtensions updated to not classify something as a heading if the content starts with 7 or more `#` signs.  Markdown typically only supports 6.
- Added the -n option for controlling heading Numbering.
- Updater implements heading number updating