### PR TITLE
Added .mdfmt profile

### DIFF
--- a/src/Mdfmt.sln
+++ b/src/Mdfmt.sln
@@ -3,34 +3,41 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mdfmt", "Mdfmt\Mdfmt.csproj", "{D74799D9-44EB-4D86-A737-0D1EAD3A5A3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mdfmt", "Mdfmt\Mdfmt.csproj", "{D74799D9-44EB-4D86-A737-0D1EAD3A5A3E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{38E87D61-EAD8-4A0E-93BB-4BB72A11AFB6}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Integration", "Integration", "{F29874EA-4531-4E5A-AF88-6871336C37C2}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integration.Mdfmt", "Tests\Integration.Mdfmt\Integration.Mdfmt.csproj", "{93595445-3EB2-476C-906E-76313C9BD3FD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Integration.Mdfmt", "Tests\Integration\Integration.Mdfmt\Integration.Mdfmt.csproj", "{5C843699-B6D0-4076-927E-51BDF3BF8DC7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unit.Mdfmt", "Tests\Unit.Mdfmt\Unit.Mdfmt.csproj", "{5D5AA1A7-548E-40D4-AE35-B704F090D120}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D74799D9-44EB-4D86-A737-0D1EAD3A5A3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D74799D9-44EB-4D86-A737-0D1EAD3A5A3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D74799D9-44EB-4D86-A737-0D1EAD3A5A3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D74799D9-44EB-4D86-A737-0D1EAD3A5A3E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5C843699-B6D0-4076-927E-51BDF3BF8DC7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5C843699-B6D0-4076-927E-51BDF3BF8DC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5C843699-B6D0-4076-927E-51BDF3BF8DC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5C843699-B6D0-4076-927E-51BDF3BF8DC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93595445-3EB2-476C-906E-76313C9BD3FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93595445-3EB2-476C-906E-76313C9BD3FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93595445-3EB2-476C-906E-76313C9BD3FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93595445-3EB2-476C-906E-76313C9BD3FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D5AA1A7-548E-40D4-AE35-B704F090D120}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D5AA1A7-548E-40D4-AE35-B704F090D120}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D5AA1A7-548E-40D4-AE35-B704F090D120}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D5AA1A7-548E-40D4-AE35-B704F090D120}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BC3C566F-059A-4489-A3C4-E165A6851BF8}
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{F29874EA-4531-4E5A-AF88-6871336C37C2} = {38E87D61-EAD8-4A0E-93BB-4BB72A11AFB6}
-		{5C843699-B6D0-4076-927E-51BDF3BF8DC7} = {F29874EA-4531-4E5A-AF88-6871336C37C2}
+		{93595445-3EB2-476C-906E-76313C9BD3FD} = {38E87D61-EAD8-4A0E-93BB-4BB72A11AFB6}
+		{5D5AA1A7-548E-40D4-AE35-B704F090D120} = {38E87D61-EAD8-4A0E-93BB-4BB72A11AFB6}
 	EndGlobalSection
 EndGlobal

--- a/src/Mdfmt/Options/CommandLineOptions.cs
+++ b/src/Mdfmt/Options/CommandLineOptions.cs
@@ -2,6 +2,9 @@
 
 namespace Mdfmt.Options;
 
+//NOTE: If you modify this class, also maintain MdfmtOptions.OverwriteExplicitlySetCommandLineOptionsOnto().
+// Is there a way to make this eaiser to maintain?  Seems like a violation of the 'O' of SOLID.
+
 public class CommandLineOptions
 {
     [Option('p', "platform", Default = Platform.Azure, HelpText = "Target platform for Markdown formatting.  One of: [Azure, VsCode].")]

--- a/src/Mdfmt/Options/FileProcessingOptions.cs
+++ b/src/Mdfmt/Options/FileProcessingOptions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+
+namespace Mdfmt.Options;
+
+public class FileProcessingOptions
+{
+    public Platform? Platform { get; set; }
+
+    public string HeadingNumbering {  get; set; }
+
+    public int? MinimumEntryCount { get; set; }
+
+    public NewlineStrategy? NewlineStrategy { get; set; }
+
+    /// <summary>
+    /// If this instance has any properties that are null, fill them in with the corresponding
+    /// properties from another instance, in an effort to make them non-null.
+    /// </summary>
+    /// <param name="other">Another instance of this class.</param>
+    public void FillGapsFrom(FileProcessingOptions other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        // Get all public instance properties
+        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (var property in properties)
+        {
+            // Only process properties that have a getter and setter
+            if (!property.CanRead || !property.CanWrite)
+                continue;
+
+            // Get the current value of the property
+            var currentValue = property.GetValue(this);
+            if (currentValue == null)
+            {
+                // Get the value from the other object and assign it
+                var newValue = property.GetValue(other);
+                property.SetValue(this, newValue);
+            }
+        }
+    }
+
+    /// <summary>
+    ///   Determine whether all properties are set to a non-null value.
+    /// </summary>
+    /// <returns>
+    ///   Returns true if and only if all properties are set to a non-null value.
+    /// </returns>
+    public bool IsComplete()
+    {
+        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        foreach (var property in properties)
+        {
+            if (!property.CanRead)
+                continue;
+            var currentValue = property.GetValue(this);
+            if (currentValue == null)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public override string ToString()
+    {
+        StringBuilder sb = new();
+        sb.Append($"  {nameof(Platform)}: {Platform}\n");
+        sb.Append($"  {nameof(HeadingNumbering)}: {HeadingNumbering}\n");
+        sb.Append($"  {nameof(MinimumEntryCount)}: {MinimumEntryCount}\n");
+        sb.Append($"  {nameof(NewlineStrategy)}: {NewlineStrategy}");
+        return sb.ToString();
+    }
+
+}

--- a/src/Mdfmt/Options/MdfmtOptions.cs
+++ b/src/Mdfmt/Options/MdfmtOptions.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Mdfmt.Options;
+
+/// <summary>
+/// This class combines various sources of knowledge about configuration, to produce the options
+/// that Mdfmt relies on to know what to do.
+/// </summary>
+/// <param name="args">
+/// The raw command line arguments passed to the program.
+/// </param>
+/// <param name="commandLineOptions">
+/// <c>CommandLineOptions</c> instance that was parsed from the raw command line arguments by the 
+/// <c>CommandLineParser</c> NuGet package.
+/// </param>
+/// <param name="mdfmtProfile">
+/// Information from a <c>.mdfmt</c> JSON file that was loaded from the root of the Mdfmt context.
+/// This is only provided if the positional argument to the <c>CommandLineParser</c> is a
+/// directory, and that directory immediately contains (i.e., not through a subdirectory)
+/// a file named <c>.mdfmt</c>.  If no <c>.mdfmt</c> file is available, this is <c>null</c>.
+/// </param>
+public class MdfmtOptions
+    (
+        string[] args,
+        CommandLineOptions commandLineOptions,
+        MdfmtProfile mdfmtProfile
+    )
+{
+    private readonly HashSet<string> _argNames = GetNamesOf(args);
+    private readonly CommandLineOptions _commandLineOptions = commandLineOptions;
+    private readonly MdfmtProfile _mdfmtProfile = mdfmtProfile;
+    private readonly FileProcessingOptions _commandLineFileProcessingOptions = FileProcessingOptionsOf(commandLineOptions);
+
+    private static HashSet<string> GetNamesOf(string[] args)
+    {
+        HashSet<string> argNames = [];
+        foreach (string arg in args)
+        {
+            if (arg.StartsWith('-'))
+            {
+                argNames.Add(arg);
+            }
+        }
+        return argNames;
+    }
+
+    private static FileProcessingOptions FileProcessingOptionsOf(CommandLineOptions commandLineOptions)
+    {
+        FileProcessingOptions fileProcessingOptions = new()
+        {
+            Platform = commandLineOptions.Platform,
+            HeadingNumbering = commandLineOptions.HeadingNumbering,
+            MinimumEntryCount = commandLineOptions.MinimumEntryCount,
+            NewlineStrategy = commandLineOptions.NewlineStrategy
+        };
+        return fileProcessingOptions;
+    }
+
+    public string Path => _commandLineOptions.Path;
+
+    public bool Verbose => _commandLineOptions.Verbose;
+
+    public bool Recursive => _commandLineOptions.Recursive;
+
+    /// <summary>
+    /// Get the options that determine how a specific Markdown file is processed.
+    /// </summary>
+    /// <param name="cpath">
+    /// The canonical relative path of a Markdown file, from the root of the Mdfmt context.
+    /// </param>
+    /// <returns>
+    /// The file procssing options to use for the specified file.
+    /// </returns>
+    public FileProcessingOptions GetFileProcessingOptions(string cpath)
+    {
+        // If a .mdfmt file was loaded into _mdfmtProfile, and it maps the cpath to an instance of
+        // FileProcessingOptions, then return based on that.
+        if (_mdfmtProfile != null && _mdfmtProfile.TryGetFileProcessingOptions(cpath, out var fileProcessingOptions))
+        {
+            // If there are file processing options that were explicitly set on the command line,
+            // then those override the options from the _mdfmtProfile.
+            OverwriteExplicitlySetCommandLineOptionsOnto(fileProcessingOptions);
+
+            // If the file processing options are incomplete, backfill from the command line.
+            // This guarantees that the returned FileProcessingOptions are complete (i.e., no null options)
+            if (!fileProcessingOptions.IsComplete())
+            {
+                Console.WriteLine("Warning: Backfilling mdfmt options from command line");
+                fileProcessingOptions.FillGapsFrom(_commandLineFileProcessingOptions);
+            }
+
+            return fileProcessingOptions;
+        }
+        // In all other cases, simply return FileProcessingOptions based on the values passed to the
+        // command line.
+        else
+        {
+            return _commandLineFileProcessingOptions;
+        }
+    }
+
+    private void OverwriteExplicitlySetCommandLineOptionsOnto(FileProcessingOptions fileProcessingOptions)
+    {
+        if (_argNames.Contains("-p") || _argNames.Contains("--platform"))
+        {
+            fileProcessingOptions.Platform = _commandLineFileProcessingOptions.Platform;
+        }
+        if (_argNames.Contains("-n") || _argNames.Contains("--heading-numbers"))
+        {
+            fileProcessingOptions.HeadingNumbering = _commandLineFileProcessingOptions.HeadingNumbering;
+        }
+        if (_argNames.Contains("--minimum-entry-count"))
+        {
+            fileProcessingOptions.MinimumEntryCount = _commandLineFileProcessingOptions.MinimumEntryCount;
+        }
+        if (_argNames.Contains("--newline-strategy"))
+        {
+            fileProcessingOptions.NewlineStrategy = _commandLineFileProcessingOptions.NewlineStrategy;
+        }
+    }
+}

--- a/src/Mdfmt/Options/MdfmtProfile.cs
+++ b/src/Mdfmt/Options/MdfmtProfile.cs
@@ -1,0 +1,66 @@
+﻿using Mdfmt.Utilities;
+using System.Collections.Generic;
+
+namespace Mdfmt.Options;
+
+/// <summary>
+/// Data loaded from .mdfmt file.
+/// </summary>
+public class MdfmtProfile
+    (
+        Dictionary<string, FileProcessingOptions> options,
+        Dictionary<string, string> cpathToOptions
+    )
+{
+    /// <summary>
+    /// Dictionary keyed on a name to the associated <c>FileProcessingOptions</c>.
+    /// </summary>
+    public Dictionary<string, FileProcessingOptions> Options { get; } = options;
+
+    /// <summary>
+    /// Dictionary mapping a cpath to an options key that is a key to the <c>Options</c> dictionary
+    /// above, indicating the <c>FileProcessingOptions</c> that apply to the cpath and its 
+    /// substructure.
+    /// </summary>
+    public Dictionary<string, string> CpathToOptions { get; } = cpathToOptions;
+
+    /// <summary>
+    /// Try to find <c>FileProcessingOptions</c> for a cpath.
+    /// </summary>
+    /// <param name="cpath">
+    ///   Canonical relative path of a Markdown file.
+    /// </param>
+    /// <param name="options">
+    ///   Output parameter that is set to the <c>FileProcessingOptions</c> that were found or to
+    ///   <c>null</c> if none found.
+    /// </param>
+    /// <returns>
+    ///   <c>true</c> if and only if an object is being returned through the <c>options</c> output
+    ///   parameter.  Note that a <c>true</c> return value does not guarantee that the returned
+    ///   object is <em>complete</em>.  See the <c>IsComplete()</c> method of class
+    ///   <c>FileProcessingOptions</c>.
+    /// </returns>
+    public bool TryGetFileProcessingOptions(string cpath, out FileProcessingOptions options)
+    {
+        options = null;
+        foreach (string leftCpath in PathUtils.LeftPaths(cpath))
+        {
+            if (CpathToOptions.TryGetValue(leftCpath, out string optionsKey))
+            {
+                FileProcessingOptions moreOptions = Options[optionsKey];
+                if (options == null)
+                {
+                    options = moreOptions;
+                }
+                else
+                {
+                    // Grab any inherited options.
+                    options.FillGapsFrom(moreOptions);
+                }
+                if (options.IsComplete())
+                    break;
+            }
+        }
+        return options != null;
+    }
+}

--- a/src/Mdfmt/Options/MdfmtProfileLoader.cs
+++ b/src/Mdfmt/Options/MdfmtProfileLoader.cs
@@ -1,0 +1,29 @@
+﻿using System.Text.Json.Serialization;
+using System.Text.Json;
+using System.IO;
+using System;
+
+namespace Mdfmt.Options;
+
+public class MdfmtProfileLoader
+{
+    public static MdfmtProfile Load(string filePath)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true, // Optional: ignore case when matching property names
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) } // Optional: Camel case support
+        };
+        string json = File.ReadAllText(filePath);
+        try
+        {
+            MdfmtProfile data = JsonSerializer.Deserialize<MdfmtProfile>(json, options);
+            return data;
+        }
+        catch (JsonException)
+        {
+            Console.WriteLine($"Error while loading Mdfmt profile JSON from {filePath}.");
+            throw;
+        }
+    }
+}

--- a/src/Mdfmt/Updaters/HeadingNumberUpdater.cs
+++ b/src/Mdfmt/Updaters/HeadingNumberUpdater.cs
@@ -7,6 +7,8 @@ namespace Mdfmt.Updaters;
 
 public static class HeadingNumberUpdater
 {
+    //TODO: I would like to be able to report whether heading numbers were changed.
+
     public static void Update(MdStruct md, string headingNumbering)
     {
         if (headingNumbering.Equals(HeadingNumbering.None, StringComparison.OrdinalIgnoreCase))
@@ -88,11 +90,6 @@ public static class HeadingNumberUpdater
                 // Set up for next iteration.  This helps us know when to zero out counters.
                 prevN = n;
             }
-        }
-        else
-        {
-            Console.WriteLine($"Invalid choice of heading numbering: {headingNumbering}.  Try the --help option.");
-            Environment.Exit(ExitCodes.MisuseOfCommand);
         }
     }
 }

--- a/src/Mdfmt/Updaters/LinkUpdater.cs
+++ b/src/Mdfmt/Updaters/LinkUpdater.cs
@@ -27,7 +27,7 @@ public class LinkUpdater(ILinkDestinationGenerator linkDestinationGenerator)
                         linkRegion.Destination = destination;
                         if (verbose)
                         {
-                            Console.WriteLine($"  Updated link with label [{linkRegion.Label}] to target destination ({linkRegion.Destination})");
+                            Console.WriteLine($"Updated link with label [{linkRegion.Label}] to target destination ({linkRegion.Destination})");
                         }
                     }
                 }
@@ -35,7 +35,7 @@ public class LinkUpdater(ILinkDestinationGenerator linkDestinationGenerator)
                 {
                     if (verbose)
                     {
-                        Console.WriteLine($"  Could not match link to heading: {linkRegion.Content}");
+                        Console.WriteLine($"Could not match link to heading: {linkRegion.Content}");
                     }
                 }
             }

--- a/src/Mdfmt/Updaters/TocUpdater.cs
+++ b/src/Mdfmt/Updaters/TocUpdater.cs
@@ -28,14 +28,17 @@ public class TocUpdater(TocGenerator tocGenerator)
                     tocRegion.Content = newToc.Content;
                     if (verbose)
                     {
-                        Console.WriteLine("  Updated TOC");
+                        Console.WriteLine("Updated TOC");
                     }
                 }
             }
             else
             {
                 md.DeleteToc();
-                Console.WriteLine("  Removed TOC");
+                if (verbose)
+                {
+                    Console.WriteLine("Removed TOC");
+                }
             }
         }
         else // The document does not have a TOC.
@@ -45,7 +48,7 @@ public class TocUpdater(TocGenerator tocGenerator)
                 md.AddToc(newToc.Content);
                 if (verbose)
                 {
-                    Console.WriteLine("  Inserted new TOC");
+                    Console.WriteLine("Inserted new TOC");
                 }
             }
         }

--- a/src/Mdfmt/Utilities/PathUtils.cs
+++ b/src/Mdfmt/Utilities/PathUtils.cs
@@ -1,27 +1,27 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace Mdfmt.Utilities;
 
-public class PathUtils(string path)
+public static class PathUtils
 {
     /// <summary>
-    /// The Path option passed to the program.  This is either the path of a directory to process,
-    /// or it is the path of of a specific Markdown file to process.
+    /// Make a path that is relative to another.
     /// </summary>
-    private readonly string _path = path;
-
-    /// <summary>
-    /// Make a relative path based on the filePath passed in.  The resulting relative path starts
-    /// with "./" and contains all forward slashes, where '.' refers to either the directory that
-    /// was passed to the program's Path option, or it refers to the directory that contains the
-    /// specific file that was passed to the program's Path option.
-    /// </summary>
-    /// <param name="filePath">File path that needs to be made relative</param>
-    /// <returns>relative version of filePath passed in</returns>
-    public string MakeRelative(string filePath)
+    /// <param name="relativeTo">
+    ///   The Path option passed to Mdfmt program.  This is either the path of a directory to 
+    ///   process, or it is the path of a specific Markdown file to process.
+    /// </param>
+    /// <param name="filePath">
+    ///   File path that needs to be made relative.
+    /// </param>
+    /// <returns>
+    ///   Relative version of filePath passed in.
+    /// </returns>
+    public static string MakeRelative(string relativeTo, string filePath)
     {
         string filename = Path.GetFileName(filePath);
-        string temporaryPath = Path.GetRelativePath(_path, filePath).Replace("\\", "/");
+        string temporaryPath = Path.GetRelativePath(relativeTo, filePath).Replace("\\", "/");
         temporaryPath = temporaryPath == "." ? filename : temporaryPath;
         string relativePath = "./" + temporaryPath;
         return relativePath;
@@ -69,4 +69,33 @@ public class PathUtils(string path)
 
         return canonicalPath;
     }
+
+    /// <summary>
+    /// <para>
+    /// Returns all the <em>left paths</em> of the path passed in, in descending length order.  A
+    /// <em>left path</em> is a path that is rooted on the left but may have 0 or more path
+    /// segments chopped off on the right.
+    /// </para>
+    /// <para>
+    /// <b>Example:</b> <c>path == "./foo/bar/baz.md"</c>
+    /// <list type="number">
+    /// <item><c>./foo/bar/baz.md</c></item>
+    /// <item><c>./foo/bar</c></item>
+    /// <item><c>./foo</c></item>
+    /// <item><c>.</c></item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    /// <param name="path">A path</param>
+    /// <returns>IEnumerable for getting all of the left paths of the path.</returns>
+    public static IEnumerable<string> LeftPaths(string path)
+    {
+        string currentPath = path;
+        while (!string.IsNullOrEmpty(currentPath))
+        {
+            yield return currentPath.Replace('\\', '/');
+            currentPath = Path.GetDirectoryName(currentPath) ?? ".";
+        }
+    }
+
 }

--- a/src/Tests/Integration.Mdfmt/Integration.Mdfmt.csproj
+++ b/src/Tests/Integration.Mdfmt/Integration.Mdfmt.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../../Mdfmt/Mdfmt.csproj" />
+    <ProjectReference Include="../../Mdfmt/Mdfmt.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Integration.Mdfmt/Loaders/LineParserTests.cs
+++ b/src/Tests/Integration.Mdfmt/Loaders/LineParserTests.cs
@@ -158,7 +158,7 @@ public class LineParserTests
     /// Expectation for the concatenation of all the content from active (uncommented) regions of
     /// the parse result.
     /// </param>
-    [Test, TestCaseSource(nameof(_lineParserTestCases))]
+    [TestCaseSource(nameof(_lineParserTestCases))]
     public void TestLineParser_Parse(bool inHtmlComment, bool expectedFinalInHtmlComment, string line, IEnumerable<Type> expectedRegionTypes, bool expectedIsActive, string expectedActiveContent)
     {
         List<Region> regions = _parser.Parse(line, inHtmlComment);

--- a/src/Tests/Unit.Mdfmt/Unit.Mdfmt.csproj
+++ b/src/Tests/Unit.Mdfmt/Unit.Mdfmt.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="NUnit.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Mdfmt/Mdfmt.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/Unit.Mdfmt/Utilities/PathUtilsTests.cs
+++ b/src/Tests/Unit.Mdfmt/Utilities/PathUtilsTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using Mdfmt.Utilities;
+
+namespace Unit.Mdfmt.Utilities;
+
+[TestFixture]
+public class PathUtilsTests
+{
+    private readonly static object[] _makeRelativeTestCases =
+    [
+        new object[] { "./file.md", "./file.md", "./file.md" },
+        new object[] { "C:\\My\\docs\\a\\b\\file.md", "C:\\My\\docs\\a\\b\\file.md", "./file.md" },
+        new object[] { "C:\\My\\docs", "C:\\My\\docs\\a\\b\\file.md", "./a/b/file.md" },
+        new object[] { "C:\\My\\docs", "C:\\My\\docs\\file.md", "./file.md" },
+        new object[] { ".", ".\\file.md", "./file.md" },
+        new object[] { "./a/b/c", "./a/b/c/d/file.md", "./d/file.md" },
+        new object[] { ".\\a\\b\\c", "./a/b/c/d/file.md", "./d/file.md" },
+    ];
+
+    [TestCaseSource(nameof(_makeRelativeTestCases))]
+    public void MakeRelativeTest(string relativeTo, string filePath, string expectedResult)
+    {
+        string result = PathUtils.MakeRelative(relativeTo, filePath);
+        Assert.That(result, Is.EqualTo(expectedResult));
+    }
+
+    private readonly static object[] _leftPathsTestCases =
+    [
+        new object[] { "./foo/bar/baz.md", new string[] {"./foo/bar/baz.md", "./foo/bar", "./foo", "."}  },
+        new object[] { "./file.md", new string[] { "./file.md", "." } },
+        new object[] { "/a/b/c/d", new string[] { "/a/b/c/d", "/a/b/c", "/a/b", "/a", "/", "." } },
+        new object[] { "hello", new string[] { "hello" } },
+        new object[] { ".", new string[] { "." } },
+        new object[] { "", System.Array.Empty<string>() },
+    ];
+
+    [TestCaseSource(nameof(_leftPathsTestCases))]
+    public void LeftPathsTest(string path, IEnumerable<string> expectedLeftPaths)
+    {
+        IEnumerable<string> leftPaths = PathUtils.LeftPaths(path);
+        Assert.That(leftPaths, Is.EquivalentTo(expectedLeftPaths));
+    }
+}


### PR DESCRIPTION
Add capability to have a .mdfmt file in the root directory being processed by Mdfmt.  Here's an example:

```JSON
{
  "Options": {
    "default": {
      "Platform": "vscode",
      "HeadingNumbering": "1.",
      "MinimumEntryCount": 3,
      "NewlineStrategy": "PreferWindows"
    },
    "special": {
      "HeadingNumbering": "none"
    }
  },
  "CpathToOptions": {
    ".": "default",
    "./foo/bar/file1.md": "special"
  }
}
```

In the `"Options"` section define multiple named configuration sections.  Each one (at this time) can define up to four options that specify what changes should be enforced on a Markdown file.  You don't have to specify all 4.  You can give a partial configuration like the `"special"` options.

The `"CpathToOptions"` section binds different canonical paths from the root of the Mdfmt context to the configuration section that should be used.  `".": "default"` means use the default options for every file processed unless there's a more specific configuration that overrides it.  In the case of the specific file `"./foo/bar/file1.md"`, the settings of the `"special"` configuration override the choice of heading numbering.  So when `file1.md` is processed, most of the settings will be from the `"default"` options, but the heading numbering is special.

Through `CpathToOptions`, you can apply options to any directory or specific file.  The settings inherit down, with more specific options always overriding ones defined higher up.

If the `.mdfmt` configuration ends up building a configuration for a given file that is missing values, the configuration is backfilled from the Mdfmt default behavior, like when you run it without a `mdfmt` file and provide no command line arguments.

If a `.mdfmt` file and command line arguments are used at the same time, then the .mdfmt mechansim computes a configuration for each file being processed, and then EXPLICITLY set command line settings are superimposed. 
