### PR TITLE
--heading-numbers option now defaults to null/unspecified

### DIFF
--- a/src/Mdfmt/Options/CommandLineOptions.cs
+++ b/src/Mdfmt/Options/CommandLineOptions.cs
@@ -1,7 +1,4 @@
 ﻿using CommandLine;
-using System;
-using System.Reflection;
-using System.Text;
 using System.Text.Json;
 
 namespace Mdfmt.Options;
@@ -13,7 +10,7 @@ internal class CommandLineOptions
     [Option('f', "flavor", Default = Flavor.Common, HelpText = "Flavor of Markdown formatting.  One of: [Common, Azure].")]
     public Flavor Flavor { get; set; }
 
-    [Option('h', "heading-numbers", Default = "1.", HelpText = "Whether to include heading numbers.  One of: [none, 1., 1].  Use 1. or 1 to include heading numbers. The name of the \"1\" options indicates whether generated numbers will end in a period.")]
+    [Option('h', "heading-numbers", HelpText = "Whether to include heading numbers.  If option omitted, no changes are made to heading numbers.  When specified, one of: [none, 1., 1].  Use none to remove heading numbers.  Use 1. or 1 to include heading numbers either with or without a trailing period.")]
     public string HeadingNumbering { get; set; }
 
     [Option('t', "toc-threshold", Default = 3, HelpText = "The minimum number of entries for which to include TOC.  0 turns off/removes TOC.")]

--- a/src/Mdfmt/Options/CommandLineOptionsValidator.cs
+++ b/src/Mdfmt/Options/CommandLineOptionsValidator.cs
@@ -7,7 +7,7 @@ internal class CommandLineOptionsValidator : AbstractValidator<CommandLineOption
     public CommandLineOptionsValidator()
     {
         RuleFor(o => o.Flavor).IsInEnum();
-        RuleFor(o => o.HeadingNumbering.ToLower()).Must(HeadingNumbering.Options.Contains).
+        RuleFor(o => o.HeadingNumbering).Must(o => o == null || HeadingNumbering.Options.Contains(o.ToLower())).
             WithMessage($"Valid options for -h and --heading-numbers: [{string.Join(',', HeadingNumbering.Options)}]");
         RuleFor(o => o.TocThreshold).GreaterThanOrEqualTo(0);
         RuleFor(o => o.NewlineStrategy).IsInEnum();

--- a/src/Mdfmt/Options/MdfmtOptions.cs
+++ b/src/Mdfmt/Options/MdfmtOptions.cs
@@ -125,11 +125,10 @@ internal class MdfmtOptions
             // then write the values from the command into fileProcessingOptions.
             OverwriteExplicitlySetCommandLineOptionsOnto(fileProcessingOptions);
 
-            // If the file processing options are incomplete, backfill from the command line.
-            // This guarantees that the returned FileProcessingOptions are complete (i.e., no null options)
+            // If the file processing options are incomplete, backfill from the command line,
+            // to make the file processing options as complete as possible.
             if (!fileProcessingOptions.IsComplete())
             {
-                Output.Warn("Warning: Backfilling mdfmt options from command line");
                 fileProcessingOptions.PopulateFrom(_commandLineFileProcessingOptions);
             }
 

--- a/src/Mdfmt/Program.cs
+++ b/src/Mdfmt/Program.cs
@@ -14,7 +14,7 @@ namespace Mdfmt;
 
 internal class Program
 {
-    private const string Version = "0.3.4";
+    private const string Version = "0.3.5";
 
     public static void Main(string[] args)
     {

--- a/src/Mdfmt/Updaters/HeadingNumberUpdater.cs
+++ b/src/Mdfmt/Updaters/HeadingNumberUpdater.cs
@@ -5,10 +5,18 @@ using System;
 
 namespace Mdfmt.Updaters;
 
+/// <summary>
+/// Updates heading numbers in section headings.
+/// </summary>
 internal static class HeadingNumberUpdater
 {
     public static void Update(MdStruct md, string headingNumbering, bool verbose)
     {
+        if (headingNumbering == null)
+        {
+            return;
+        }
+
         bool headingsModified = false;
 
         if (headingNumbering.Equals(HeadingNumbering.None, StringComparison.OrdinalIgnoreCase))
@@ -90,7 +98,11 @@ internal static class HeadingNumberUpdater
                 // Set up for next iteration.  This helps us know when to zero out counters.
                 prevN = n;
             } // end foreach headingRegion
-        } // end if
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unhandled kind of heading numbering: {headingNumbering}");
+        }
 
         if (headingsModified && verbose)
         {

--- a/src/Tests/Integration.Mdfmt/ProgramTests.cs
+++ b/src/Tests/Integration.Mdfmt/ProgramTests.cs
@@ -86,8 +86,8 @@ public class ProgramTests
         new TestCaseData(_title_toc_md, new string[] {"-t", "1"}, _title_toc_md, ExitCodes.Success).
         SetName("TOC.6: Given a file with a title and TOC, When mdfmt -t 1, Then no change."),
 
-        new TestCaseData(_title_toc_outdated_md, new string[] {"-t", "1"}, _title_toc_updated_md, ExitCodes.Success).
-        SetName("TOC.7: Given a file with an outdated TOC, When mdfmt -t 1, Then the TOC is updated."),
+        new TestCaseData(_title_toc_outdated_md, new string[] {"-t", "1", "-h", "1."}, _title_toc_updated_md, ExitCodes.Success).
+        SetName("TOC.7: Given a file with an outdated TOC, When mdfmt -t 1 -h 1., Then the TOC is updated."),
 
 
 


### PR DESCRIPTION
It used to be that when the --heading-numbers option was omitted on the command line, that the setting defaulted to "1.", but now it defaults to null which means don't make any changes to heading numbers.  This makes the program less opinionated, and allows people to say what they want explicitly rather than being subjected to arbitrary default behavior.

There's more of this type of work to do; this is a step in the right direction.