### PR TITLE
Moved some tests from Integration to Unit

### DIFF
--- a/src/Tests/Integration.Mdfmt/Data/README.md
+++ b/src/Tests/Integration.Mdfmt/Data/README.md
@@ -2,6 +2,6 @@
 
 The `Data` folder has test data to support testing.
 
-It is important to provide the data in ProgramTests.zip in a zipped form, because some the tests
+It is important to provide the data in ProgramTests.zip in a zipped form, because some tests
 rely on specific newline characters (`\n` vs `"\r\n"`), and newline characters can change when
 checking in and out of repositories, which could mess up the test data.

--- a/src/Tests/Unit.Mdfmt/Loaders/FileContentParserTests.cs
+++ b/src/Tests/Unit.Mdfmt/Loaders/FileContentParserTests.cs
@@ -1,7 +1,7 @@
 ﻿using Mdfmt.Loaders;
 using System.Collections.Generic;
 
-namespace Integration.Mdfmt.Loaders;
+namespace Unit.Mdfmt.Loaders;
 
 [TestFixture]
 public class FileContentParserTests

--- a/src/Tests/Unit.Mdfmt/Loaders/LineParserTests.cs
+++ b/src/Tests/Unit.Mdfmt/Loaders/LineParserTests.cs
@@ -3,7 +3,7 @@ using Mdfmt.Model;
 using System;
 using System.Collections.Generic;
 
-namespace Integration.Mdfmt.Loaders;
+namespace Unit.Mdfmt.Loaders;
 
 [TestFixture]
 public class LineParserTests


### PR DESCRIPTION
Moved some tests, that were misclassified as integration tests, to the unit test area, just to keep things organized.