### PR TITLE
Base configuration with environment-specific override

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Summary
 
-Mdfmt is a command line interface (CLI) for Markdown formatting.  While it was initially developed to support software documentation development, it is a general purpose tool that is also applicable to other use cases.  Able to operate on individual Markdown files or on directory structures containing many Markdown files, it offers assistance with automated maintenance of heading numbers, in-document links, table of contents, line numbering of fenced code blocks, and consistent newlines.  It is a work in progress, and new features continue to be added.
+Mdfmt is a command line interface (CLI) for Markdown formatting.  Able to operate on individual Markdown files and on directory structures containing many Markdown files, it automates maintenance of heading numbers, in-document links, table of contents, line numbering of fenced code blocks, consistent newlines, etc.  Mdfmt is designed to help with both simple use cases where only one kind of formatting is required, and with more complex use cases involving multiple target Markdown rendering environments with different formatting needs.
+
+Mdfmt is a work in progress, and new features continue to be added.
 
 Mdfmt is being developed in C#/.NET 8.0, with plans to upgrade to the next LTS version of .NET when it comes out.
 
@@ -17,8 +19,8 @@ Mdfmt is being developed in C#/.NET 8.0, with plans to upgrade to the next LTS v
   - Optionally autogenerates table of contents based on document headings.  The resulting table of contents allows navigation to each section of the document.
   - Adds or removes line numbers to or from fenced code blocks, which can be useful when different rendering environments either do or do not automatically show line numbers.
   - Supports different strategies for managing newline characters in Markdown files, which can be tricky in a cross-platform environment.
-- When working on a documentation repository, or more generally any time there is a directory structure containing Markdown files, supports creation of a configuration file that specifies how to format the Markdown files in the directory and its subfolders.
-  - This configuration supports a flexible inheritance scheme, where you can specify in general how to format the Markdown, and override the general behavior in specific subdirectories or even individual files.  For example, maybe you prefer heading numbers in general, but not in a document that is a glossary containing a flat list of terms, where the heading numbers would be distracting not helpful.
+- When working on a documentation repository, or more generally any time there is a directory structure containing Markdown files, supports creation of configuration files that specify how to format the Markdown files in the directory and its subfolders.
+  - Mdfmt configuration supports a flexible inheritance scheme, where you can specify in general how to format the Markdown, and override the general behavior in specific subdirectories or even individual files.  For example, maybe you prefer heading numbers in general, but not in a document that is a glossary containing a flat list of terms, where the heading numbers would be distracting not helpful.
   - Different configuration files for different target rendering environments is supported, and it is easy to switch between them.
 
 ## Getting Started

--- a/docs/mdfmt.json
+++ b/docs/mdfmt.json
@@ -3,7 +3,8 @@
     "default": {
       "Flavor": "Common",
       "TocThreshold": 3,
-      "HeadingNumbering": "1."
+      "HeadingNumbering": "1.",
+      "LineNumberingThreshold": 0
     },
     "noHeadings": {
       "HeadingNumbering": "none"

--- a/docs/user/Glossary.md
+++ b/docs/user/Glossary.md
@@ -5,11 +5,14 @@
   - [cpath](#cpath)
   - [current working directory](#current-working-directory)
   - [destination](#destination)
+  - [environment](#environment)
+  - [fenced code block](#fenced-code-block)
   - [label](#label)
+  - [line numbering threshold](#line-numbering-threshold)
   - [link](#link)
   - [Markdown](#markdown)
   - [Mdfmt](#mdfmt)
-  - [mdfmt configuration file](#mdfmt-configuration-file)
+  - [mdfmt configuration files](#mdfmt-configuration-files)
   - [processing root](#processing-root)
   - [slug](#slug)
   - [slugification](#slugification)
@@ -24,24 +27,31 @@ This file defines terms that form the ubiquitous language of Mdfmt.
 
 ## cpath
 
-the canonical relative path of a file being processed by [Mdfmt](#mdfmt).  Such a path is relative to the [processing root](#processing-root), where the [mdfmt configuration file](#mdfmt-configuration-file) (if any) is.  _Cpaths_ are used as keys in the [mdfmt configuration file](#mdfmt-configuration-file) to bind sets of formatting options to directories or to individual files.
+the canonical relative path of a file being processed by [Mdfmt](#mdfmt).  Such a path is relative to the [processing root](#processing-root), where any [mdfmt configuration files](#mdfmt-configuration-files) are.  _Cpaths_ are used as keys in the [mdfmt configuration files](#mdfmt-configuration-files) to bind sets of formatting options to directories or to individual files.
 
 ## current working directory
 
-the directory in which [Mdfmt](#mdfmt) was launched and that is dynamically associated with the running program.
-
-Uses of the _current working directory_ by [Mdfmt](#mdfmt):
-
-1. When the [target path](#target-path) that [Mdfmt](#mdfmt) is being asked to process is a relative path, this path is understood relative to the _current working directory_.
-2. When determing the [processing root](#processing-root) of the [Mdfmt](#mdfmt) run, in the absence of an [mdfmt configuration file](#mdfmt-configuration-file), the _current working directory_ is used as the [processing root](#processing-root).
+the directory in which [Mdfmt](#mdfmt) was launched and that is dynamically associated with the running program.  The _current working directory_ is important for resolving omitted and relative [target path](#target-path).
 
 ## destination
 
 a URL or relative path indicating the navigation target of a [link](#link) in a [Markdown](#markdown) document.
 
+## environment
+
+when developting [Markdown](#markdown) files, _environment_ refers to where the files will be rendered.  Examples include a website such as [Github](https://github.com), a developer laptop, or a developer portal such as [Backstage](https://backstage.io).  [Mdfmt](#mdfmt) supports configuring different formatting options per _environment_, and designating the target _environment_ for formatting on the command line.
+
+## fenced code block
+
+a region of [Markdown](#markdown) that both starts with and ends with a line where the first non-whitespace characters are three backquotes.  Markdown rendering shows such a region as a block of code. [Mdfmt](#mdfmt) supports adding line numbers to such code blocks.  See [line numbering threshold](#line-numbering-threshold).
+
 ## label
 
 the text of a [link](#link) that is rendered as part of a [Markdown](#markdown) document as a clickable hyperlink.
+
+## line numbering threshold
+
+an integer greater than or equal to 0, indicating the minimum number of lines in a [fenced code block](#fenced-code-block) for which [Mdfmt](#mdfmt) will ensure line numbers.  A _line numbering threshold_ of 0 removes line numbering from [fenced code blocks](#fenced-code-block).
 
 ## link
 
@@ -65,23 +75,25 @@ Since its introduction, Markdown has been widely adopted.  There are numerous im
 
 a CLI tool for formatting either individual [Markdown](#markdown) files or all the [Markdown](#markdown) files found in a directory.
 
-## mdfmt configuration file
+## mdfmt configuration files
 
-an optional configuration file that specifies formatting options applied by [Mdfmt](#mdfmt) to [Markdown](#markdown) files.
+one or more optional configuration files immediately in the [processing root](#processing-root) directory (not in a subdirectory), specifying formatting options applied by [Mdfmt](#mdfmt) to [Markdown](#markdown) files.
 
-How the file itself (not considering path) is expected to be named: If the `-e, --environment` option has been specified, the _mdfmt configuration file_ is expected to be named `mdfmt.{environment}.json`, where `{environment}` is replaced by value passed to the `-e, --environment` option.  If the `-e, --environment` is not being used, the expected name of the file is simply `.mdfmt`.
+_Mdfmt configuration files_ are recognizable by their names:
 
-How the file is located at runtime:  [Mdfmt](#mdfmt) first looks in the [target directory](#target-directory), then in the parent directory (if any) of the [target directory](#target-directory), and on up to all ancestor directories:  The first directory that contains a file with the expected name of the _mdfmt configuration file_ defines the [processing root](#processing-root).  The configuration file is then loaded, and it governs the formatting that is applied to all [Markdown](#markdown) files that are formatted within the [processing root](#processing-root) and any of its subdirectories.  Canonical relative paths, or [cpaths](#cpath), configured in the _mdfmt configuration file_ are relative to the [processing root](#processing-root).
+- `.mdfmt` - This file plays the same role as `mdfmt.json` (see next bullet).  The file name, `.mdfmt`, is deprecated; use the name `mdfmt.json` instead.
+- `mdfmt.json` - Base formatting options that apply to all Markdown files in the folder where specified and in all subfolders.  These base options apply unless overridden in an [environment](#environment)-specific _configuration file_ (see next bullet).
+- `mdfmt.{environment}.json` - File with [environment](#environment)-specific formatting overrides.  This file must be in the same directory as `mdfmt.json`.  It is used to override and extend settings from `mdfmt.json`, for a specific [environment](#environment).
 
-Formatting options explicitly provided on the command line are more powerful than, and will override, formatting options provided through the _mdfmt configuration file_.
+Formatting options explicitly provided on the command line are more powerful than, and will override, formatting options provided through the _mdfmt configuration files_.
 
-The _mdfmt configuration file_ is optional.  If not present, then the [current working directory](#current-working-directory) is used as the [processing root](#processing-root), and only command line options govern the formatting that happens.
+Use of _mdfmt configuration files_ is optional.  If there are no _configuration files_, then the [target directory](#target-directory) is used as the [processing root](#processing-root), and only command line options govern the formatting that happens.
 
 ## processing root
 
-a directory that defines the root of files that [Mdfmt](#mdfmt) can see.  [Mdfmt](#mdfmt) can only format `.md` files that are in the _processing root_ directory or one of its subdirectories, and the program is unaware of any other files outside the _processing root_.
+a directory that defines the root of files that [Mdfmt](#mdfmt) can see and process.  [Mdfmt](#mdfmt) can only format `.md` files that are in the _processing root_ directory and its subdirectories.
 
-If there exists an [mdfmt configuration file](#mdfmt-configuration-file), the directory containing it, by definition, is the _processing root_.
+It is always the case that the _processing root_ either is the [target directory](#target-directory) or an ancestor directory of the [target directory](#target-directory).  Starting in the [target directory](#target-directory) and scanning up the file system to successive ancestor directories, the _processing root_ is the first directory that contains any [mdfmt configuration files](#mdfmt-configuration-files).
 
 ## slug
 
@@ -97,11 +109,11 @@ a region of a [Markdown](#markdown) document that [Mdfmt](#mdfmt) maintains.  It
 
 ## target path
 
-a path that [Mdfmt](#mdfmt) is being asked to process, specified on the command line as an absolute or relative path indicating either an individual [Markdown](#markdown) (`.md`) file or a directory.  When a relative path, it is relative to the [current working directory](#current-working-directory).  If a directory as opposed to a specific file, it means to process the [Markdown](#markdown) files in the directory (and optionally subdirectories depending on the `-r, --recursive` option).  If the _target path_ is not specified, it defaults to the [current working directory](#current-working-directory).
+the path that [Mdfmt](#mdfmt) is being asked to process, optionally specified on the command line as either an absolute path or relative path.  When omitted from the command line, it defaults to the [current working directory](#current-working-directory).  When a relative path, it is relative to the [current working directory](#current-working-directory).  The _target path_ indicates either an individual [Markdown](#markdown) (`.md`) file or a directory.  If an individual file, it means only that file should be processed.  If a directory, it means to process the files in that directory, and in subdirectories too if the `-r --recursive` option is specified.
 
 ## target directory
 
-The directory of the [target path](#target-path).  There are two cases:
+The directory of the [target path](#target-path):
 
 - If the [target path](#target-path) indicates a specific [Markdown](#markdown) (`.md`) file, then the _target directory_ is the directory containing this specific file.
 - If the [target path](#target-path) indicates a directory, then the _target directory_ and [target path](#target-path) are one and the same.

--- a/src/Mdfmt/Options/CommandLineOptions.cs
+++ b/src/Mdfmt/Options/CommandLineOptions.cs
@@ -7,7 +7,7 @@ namespace Mdfmt.Options;
 
 internal class CommandLineOptions
 {
-    [Option('e', "environment", HelpText = "Optional environment name affecting configuration.  When specified, Mdfmt looks for a file named, \"mdfmt.{environment}.json\".  When omitted, Mdfmt looks for a file named \".mdfmt\".  Directory location: Mdfmt first looks in the directory of the target path, then in the parent directory if any, then in ancestor directories, until found.  If not found, Mdfmt still runs, just without configuration file input.  Explicit formatting from command line overrides formatting from configuration file.")]
+    [Option('e', "environment", HelpText = "Optional environment name.  When specified, Mdfmt insists on a file named \"mdfmt.{environment}.json\" in the processing root, and provided settings override and/or extend the optional base configuration of either mdfmt.json or .mdfmt (.mdfmt file is deprecated).")]
     public string Environment { get; set; }
 
     [Option('f', "flavor", HelpText = "Flavor of link slugification.  When specified, one of: [Common, Azure], causing in-document links, including both those in the body of the document and in any pre-existing table of contents (TOC), to be updated for the flavor.  If this option is omitted, links are not updated.  If the value of the -t option > 0, then this -f option is required, to inform the flavor of TOC link destinations.")]

--- a/src/Mdfmt/Options/ConfigFilesFinder.cs
+++ b/src/Mdfmt/Options/ConfigFilesFinder.cs
@@ -1,0 +1,145 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace Mdfmt.Options;
+
+/// <summary>
+/// <para>
+/// Find optional config files that provide instructions to Mdfmt.  (When configuration files are
+/// absent, only the command line tells Mdfmt what to do. When configuration files are present,
+/// formatting from the command line takes priority over formatting from configuration files.)
+/// </para>
+/// <para>
+/// To use this class:  Instantiate it with the command line options passed to the program and the
+/// <c>targetPathIsDirectory</c> flag.  Then, read the <c>ProcessingRoot</c> property to know the
+/// directory containing config files, and read the <c>MdfmtConfigurationFilePaths</c> property to
+/// know the full paths of all configuration files, in the order they should be loaded.
+/// </para>
+/// </summary>
+internal class ConfigFilesFinder
+{
+    /// <summary>
+    /// Command line options passed to the program.
+    /// </summary>
+    private CommandLineOptions CommandLineOptions { get; }
+
+    /// <summary>
+    /// If Mdfmt is processing a single file, this is the path of the directory containing the file,
+    /// and if Mdfmt is processing the Markdown files in a directory, this is the path of that directory.
+    /// </summary>
+    private string TargetDirectory { get; }
+
+    /// <summary>
+    /// The processing root path, which defines the scope of files Mdfmt can see.  Any configuration 
+    /// files are directly in this directory.
+    /// </summary>
+    public string ProcessingRoot { get; internal set; }
+
+    /// <summary>
+    /// Backing storage for the <c>MdfmtConfigurationFilePaths</c> property.
+    /// </summary>
+    private readonly List<string> _mdfmtConfigurationFilePaths = [];
+
+    /// <summary>
+    /// A list of full paths of configuration file(s) to load, or null or empty list if there are no
+    /// configuration files to load.
+    /// </summary>
+    public IReadOnlyList<string> MdfmtConfigurationFilePaths => _mdfmtConfigurationFilePaths;
+
+    /// <summary>
+    /// Constructor of class <c>ConfigFilesFinder</c>.  Throws <see cref="ExitException"/> if an
+    /// environment was specified on the command line, and the configuration file for this
+    /// environment is not found.
+    /// </summary>
+    /// <param name="commandLineOptions">
+    /// Command line options provided to the program.
+    /// </param>
+    /// <param name="targetPathIsDirectory">
+    /// <c>true</c> if the target path Mdfmt is being asked to process is a directory, and <c>false</c>
+    /// if it is an individual file.
+    /// </param>
+    /// <exception cref="ExitException"/>
+    public ConfigFilesFinder(CommandLineOptions commandLineOptions, bool targetPathIsDirectory)
+    {
+        CommandLineOptions = commandLineOptions;
+        TargetDirectory = targetPathIsDirectory ? commandLineOptions.TargetPath : Path.GetDirectoryName(commandLineOptions.TargetPath);
+        FinishInitializing();
+    }
+
+    /// <summary>
+    /// Set up the <c>ProcessingRoot</c> and <c>MdfmtConfigurationFilePaths</c> properties.
+    /// Throws an <see cref="ExitException"/> if an environment was specified on the command
+    /// line, and the configuration file for this environment is not found.
+    /// </summary>
+    /// <exception cref="ExitException"/>
+    private void FinishInitializing()
+    {
+        bool lookingForEnvironmentSpecificFile = !string.IsNullOrEmpty(CommandLineOptions.Environment);
+
+        // Foreach directory starting with the TargetDirectory and then each ancestor directory...
+        DirectoryInfo directoryInfo = new(TargetDirectory);
+        do
+        {
+            string candidateProcessingRoot = directoryInfo.FullName;
+            string dotMdfmtFile = Path.Combine(candidateProcessingRoot, ".mdfmt");
+            string mdfmtJsonFile = Path.Combine(candidateProcessingRoot, "mdfmt.json");
+            string envSpecificFile = lookingForEnvironmentSpecificFile ?
+                Path.Combine(candidateProcessingRoot, $"mdfmt.{CommandLineOptions.Environment}.json") :
+                null;
+            bool dotMdfmtFileExists = File.Exists(dotMdfmtFile);
+            bool mdfmtJsonFileExists = File.Exists(mdfmtJsonFile);
+            bool envSpecificFileExists = lookingForEnvironmentSpecificFile && File.Exists(envSpecificFile);
+            if (dotMdfmtFileExists || mdfmtJsonFileExists || envSpecificFileExists)
+            {
+                // Processing root found, based on presence of configuration.
+                ProcessingRoot = candidateProcessingRoot;
+
+                // First add file containing base configuration, if any, to MdfmtConfigurationFilePaths.
+                if (dotMdfmtFileExists && mdfmtJsonFileExists)
+                {
+                    Output.Warn($"Ignoring {dotMdfmtFile} and using {mdfmtJsonFile}.");
+                    _mdfmtConfigurationFilePaths.Add(mdfmtJsonFile);
+                }
+                else if (dotMdfmtFileExists)
+                {
+                    _mdfmtConfigurationFilePaths.Add(dotMdfmtFile);
+                }
+                else if (mdfmtJsonFileExists)
+                {
+                    _mdfmtConfigurationFilePaths.Add(mdfmtJsonFile);
+                }
+
+                // If looking for an environment-specific file (because an environment was specified
+                // on the command line) then either add it to MdfmtConfigurationFilePaths or throw
+                // if not found.
+                if (lookingForEnvironmentSpecificFile)
+                {
+                    if (envSpecificFileExists)
+                    {
+                        _mdfmtConfigurationFilePaths.Add(envSpecificFile);
+                    }
+                    else
+                    {
+                        Output.Error($"Environment \"{CommandLineOptions.Environment}\" was specified on the command line, but file {envSpecificFile} was not found.");
+                        throw new ExitException(ExitCodes.MisuseOfCommand);
+                    }
+                }
+
+                // Initialization complete.
+                return;
+            }
+        } while ((directoryInfo = directoryInfo.Parent) != null);
+
+        // Since we scanned all the way to the root of the file system without finding configuration
+        // files, then use the target directory as the processing root.
+        ProcessingRoot = new DirectoryInfo(TargetDirectory).FullName;
+
+        if (lookingForEnvironmentSpecificFile)
+        {
+            // If we get here, no config files were found.  So if we were looking for an environment-specific
+            // configuration file, that's a problem.
+            Output.Error($"Environment \"{CommandLineOptions.Environment}\" was specified on the command line but no mdfmt.{CommandLineOptions.Environment}.json file was found, neither in {ProcessingRoot} nor in an ancestor directory.");
+            throw new ExitException(ExitCodes.MisuseOfCommand);
+        }
+    }
+}

--- a/src/Mdfmt/Options/FormattingOptions.cs
+++ b/src/Mdfmt/Options/FormattingOptions.cs
@@ -65,6 +65,28 @@ internal class FormattingOptions
     }
 
     /// <summary>
+    /// If another instance has properties that are non-null, copy them onto this instance, to
+    /// implement configuration override functionality.
+    /// </summary>
+    /// <param name="other">Another instance of this class.</param>
+    public void OverwriteFrom(FormattingOptions other)
+    {
+        ArgumentNullException.ThrowIfNull(other);
+
+        // Get all public instance properties
+        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+        foreach (var property in properties)
+        {
+            var otherValue = property.GetValue(other);
+            if (otherValue != null)
+            {
+                property.SetValue(this, otherValue);
+            }
+        }
+    }
+
+    /// <summary>
     /// Determine whether all properties are set to a non-null value.
     /// </summary>
     /// <returns>

--- a/src/Mdfmt/Options/FormattingOptionsValidator.cs
+++ b/src/Mdfmt/Options/FormattingOptionsValidator.cs
@@ -7,9 +7,10 @@ internal class FormattingOptionsValidator : AbstractValidator<FormattingOptions>
 {
     public FormattingOptionsValidator()
     {
-        RuleFor(o => o.Flavor).Must((v) => { return v == null || Enum.IsDefined(typeof(Flavor), v); });
-        RuleFor(o => o.HeadingNumbering).Must((v) => { return v == null || HeadingNumbering.Options.Contains(v); });
-        RuleFor(o => o.TocThreshold).Must((v) => { return v == null || (int)v >= 0; });
-        RuleFor(o => o.NewlineStrategy).Must((v) => { return v == null || Enum.IsDefined(typeof(NewlineStrategy), v); });
+        RuleFor(o => o.Flavor).Must(v => v == null || Enum.IsDefined(typeof(Flavor), v)).WithMessage(o => $"Invalid Flavor: \"{o.Flavor}\"");
+        RuleFor(o => o.HeadingNumbering).Must(v => v == null || HeadingNumbering.Options.Contains(v)).WithMessage(o => $"Invalid HeadingNumbering option: \"{o.HeadingNumbering}\"");
+        RuleFor(o => o.TocThreshold).Must(v => v == null || (int)v >= 0).WithMessage("TocThreshold must not be negative.");
+        RuleFor(o => o.LineNumberingThreshold).Must(v => v == null || (int)v >= 0).WithMessage("LineNumberingThreshold must not be negative.");
+        RuleFor(o => o.NewlineStrategy).Must(v => v == null || Enum.IsDefined(typeof(NewlineStrategy), v)).WithMessage(o => $"Invalid NewlineStrategy: \"{o.NewlineStrategy}\"");
     }
 }

--- a/src/Mdfmt/Options/MdfmtOptions.cs
+++ b/src/Mdfmt/Options/MdfmtOptions.cs
@@ -16,18 +16,22 @@ namespace Mdfmt.Options;
 /// <c>CommandLineParser</c> NuGet package.
 /// </param>
 /// <param name="processingRoot">
-/// Full path defining the root of files that Mdfmt can see and process.
+/// Full path defining the root of files that Mdfmt can see and process.  When there are
+/// configuration files present, the directory in which these files exist defines the processing
+/// root.  When there are no configuration files, the directory of the target path is used.
+/// (The target path defines either the single Markdown file, or the directory, being processed
+/// by the program.)
 /// </param>
-/// <param name="mdfmtConfigurationFilePath">
-/// The full path of a file in the <c>processingRoot</c> directory that is a configuration file from
-/// which to load a <see cref="MdfmtProfile"/>, or <c>null</c> if there is no such file.
+/// <param name="mdfmtConfigurationFilePaths">
+/// A list of full paths of configuration file(s) to load, or null or empty list if there are no
+/// configuration files to load.  This is for optionally loading <see cref="MdfmtProfile"/>.
 /// </param>
 internal class MdfmtOptions
     (
         string[] args,
         CommandLineOptions commandLineOptions,
         string processingRoot,
-        string mdfmtConfigurationFilePath
+        IReadOnlyList<string> mdfmtConfigurationFilePaths
     )
 {
     /// <summary>
@@ -50,16 +54,16 @@ internal class MdfmtOptions
     public string ProcessingRoot { get; } = processingRoot;
 
     /// <summary>
-    /// The full path of a file in the <c>ProcessingRoot</c> directory that is a configuration file from
-    /// which to load a <see cref="MdfmtProfile"/>, or <c>null</c> if there is no such file.
+    /// A list of full paths of configuration file(s) to load, or null or empty list if there are no
+    /// configuration files to load.  This is for optionally loading the <see cref="MdfmtProfile"/>.
     /// </summary>
-    public string MdfmtConfigurationFilePath { get; } = mdfmtConfigurationFilePath;
+    public IReadOnlyList<string> MdfmtConfigurationFilePaths { get; } = mdfmtConfigurationFilePaths;
 
     /// <summary>
-    /// A data structure with information loaded from the <c>MdfmtConfigurationFilePath</c>, or <c>null</c> if
-    /// the <c>MdfmtConfigurationFilePath</c> is <c>null</c>, and so there is no data structure to load.
+    /// A data structure with information loaded from configuration file(s) or null if there are no
+    /// configuration files to load.
     /// </summary>
-    public MdfmtProfile MdfmtProfile { get; } = (mdfmtConfigurationFilePath == null) ? null : MdfmtProfileLoader.Load(mdfmtConfigurationFilePath);
+    public MdfmtProfile MdfmtProfile { get; } = MdfmtProfileLoader.Load(mdfmtConfigurationFilePaths);
 
     /// <summary>
     /// Instance of <see cref="FormattingOptions"/> instantiated based on command line options.

--- a/src/Mdfmt/Options/MdfmtProfile.cs
+++ b/src/Mdfmt/Options/MdfmtProfile.cs
@@ -26,6 +26,36 @@ internal class MdfmtProfile
     public Dictionary<string, string> CpathToOptions { get; } = new Dictionary<string, string>(cpathToOptions ?? [], StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Given another instance of this class, superimpose its configuration on this one to implement
+    /// configuration override.
+    /// </summary>
+    /// <param name="other">Another <c>MdfmtProfile</c> instance</param>
+    public MdfmtProfile OverwriteOptionsFrom(MdfmtProfile other)
+    {
+        foreach (string key in other.Options.Keys)
+        {
+            if (Options.TryGetValue(key, out FormattingOptions formattingOptions))
+            {
+                // This MdfmtProfile and the other one both have FormattingOptions with the same key.
+                // Overwrite the FormattingOptions in this MdfmtProfile with non-null values from 
+                // the other one.
+                formattingOptions.OverwriteFrom(other.Options[key]);
+            }
+            else
+            {
+                // The other MdfmtProfile has FormattingOptions with a key that does not exist in
+                // this MdfmtProfile.  Add this key/value pair to this MdfmtProfile.
+                Options[key] = other.Options[key];
+            }
+        }
+        foreach (string key in other.CpathToOptions.Keys)
+        {
+            CpathToOptions[key] = other.CpathToOptions[key];
+        }
+        return this;
+    }
+
+    /// <summary>
     /// Try to find <see cref="FormattingOptions"/> for a cpath.
     /// </summary>
     /// <param name="cpath">

--- a/src/Mdfmt/Options/MdfmtProfileLoader.cs
+++ b/src/Mdfmt/Options/MdfmtProfileLoader.cs
@@ -3,46 +3,84 @@ using System.Text.Json;
 using System.IO;
 using FluentValidation;
 using System;
+using System.Collections.Generic;
 
 namespace Mdfmt.Options;
 
 /// <summary>
-/// Static class providing a method to load a JSON configuration file into an instance of <see cref="MdfmtProfile"/>.
+/// <para>
+/// Static class providing a method to load and combine a sequence of JSON configuration files into
+/// an instance of <see cref="MdfmtProfile"/>.
+/// </para>
 /// </summary>
 internal static class MdfmtProfileLoader
 {
     /// <summary>
-    /// Load a configuration file into a new instance of <see cref="MdfmtProfile"/>.
-    /// Note that property names enum values in the file are case-insensitive,
-    /// and extra properties are disallowed.
+    /// Configuration for deserialization details for loading JSON files.
     /// </summary>
-    /// <param name="filePath">The path of the configuration file to load as the <c>MdfmtProfile</c>></param>
-    /// <returns>
-    /// Validated <see cref="MdfmtProfile"/> instance.  For details of the validation, see <see cref="MdfmtProfileValidator"/>.
-    /// </returns>
-    public static MdfmtProfile Load(string filePath)
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
-        // Options for JSON deserialization.
-        var options = new JsonSerializerOptions
+        // Ignore case when matching property names
+        PropertyNameCaseInsensitive = true,
+
+        // Allows enums to be specified by name, with any casing, including 
+        // lowercase, ALL CAPS, camelCase, PascalCase, and anything inbetween.
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+
+        // Disallow the presence of extra members in the JSON that are not supported
+        // by the target class in C#.
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
+    };
+
+    /// <summary>
+    /// Load and combine a sequence of JSON configuration files into a new instance of
+    /// <see cref="MdfmtProfile"/>. When there are multiple files being loaded, each
+    /// subsequent file combines its non-null settings with the first, overriding any
+    /// duplicate settings.
+    /// </summary>
+    /// <param name="filePaths">
+    /// A list of 0 or more file paths.  Empty list and <c>null</c> are semantically
+    /// equivalent, indicating that there are no files to load.
+    /// </param>
+    /// <returns>
+    /// Loaded <see cref="MdfmtProfile"/>, or null if no files to load.
+    /// </returns>
+    public static MdfmtProfile Load(IReadOnlyList<string> filePaths)
+    {
+        if (filePaths == null) return null;
+        MdfmtProfile result = null;
+        foreach (string filePath in filePaths)
         {
-            // Ignore case when matching property names
-            PropertyNameCaseInsensitive = true,
+            MdfmtProfile current = Load(filePath);
+            result = (result == null) ? current : result.OverwriteOptionsFrom(current);
+        }
 
-            // Allows enums to be specified by name, with any casing, including 
-            // lowercase, ALL CAPS, camelCase, PascalCase, and anything inbetween.
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        // Ensure result to be returned is valid
+        if (result != null)
+        {
+            MdfmtProfileValidator validator = new(result);
+            validator.ValidateAndThrow(result);
+        }
 
-            // Disallow the presence of extra properties in the JSON that are not supported
-            // by the target schema in C#.
-            UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow
-        };
+        return result;
+    }
 
+    /// <summary>
+    /// Load a single configuration file into a new instance of <see cref="MdfmtProfile"/>.
+    /// </summary>
+    /// <param name="filePath">
+    /// The path of the configuration file to load.
+    /// </param>
+    /// <returns>
+    /// <see cref="MdfmtProfile"/> instance, not yet validated.  Validation is deferred
+    /// until all configurations have been combined.
+    /// </returns>
+    private static MdfmtProfile Load(string filePath)
+    {
         try
         {
             string json = File.ReadAllText(filePath);
-            MdfmtProfile mdfmtProfile = JsonSerializer.Deserialize<MdfmtProfile>(json, options);
-            MdfmtProfileValidator validator = new(filePath, mdfmtProfile);
-            validator.ValidateAndThrow(mdfmtProfile);
+            MdfmtProfile mdfmtProfile = JsonSerializer.Deserialize<MdfmtProfile>(json, _jsonSerializerOptions);
             return mdfmtProfile;
         }
         catch (Exception)

--- a/src/Mdfmt/Processor.cs
+++ b/src/Mdfmt/Processor.cs
@@ -67,7 +67,30 @@ internal class Processor
             Output.Info($"Absolute TargetPath: {Path.GetFullPath(_options.CommandLineOptions.TargetPath)}{Environment.NewLine}");
             Output.Info($"Explicitly Set Option Names:{Environment.NewLine}{(_options.ArgNames.Count == 0 ? "none" : string.Join(", ", _options.ArgNames))}{Environment.NewLine}");
             Output.Info($"Processing Root: {_options.ProcessingRoot}{Environment.NewLine}");
-            Output.Info($"Mdfmt configuration file: {_options.MdfmtConfigurationFilePath ?? "none"}");
+
+            string loadedFromInfo;
+            if (_options.MdfmtConfigurationFilePaths == null || _options.MdfmtConfigurationFilePaths.Count == 0)
+            {
+                loadedFromInfo = ": none";
+            }
+            else if (_options.MdfmtConfigurationFilePaths.Count == 1)
+            {
+                loadedFromInfo = $": {_options.MdfmtConfigurationFilePaths[0]}";
+            }
+            else
+            {
+                loadedFromInfo = $" loaded from the following files:";
+            }
+            Output.Info($"Mdfmt configuration file{loadedFromInfo}");
+
+            if (_options.MdfmtConfigurationFilePaths.Count > 1)
+            {
+                foreach (string filePath in _options.MdfmtConfigurationFilePaths)
+                {
+                    Output.Info($"  - {filePath}");
+                }
+            }
+
             if (_options.MdfmtProfile != null)
             {
                 Output.Info(_options.MdfmtProfile);


### PR DESCRIPTION
- Deprecated the .mdfmt file.
- Add support for mdfmt.json as the preferred way of specifying base configuration.
- mdfmt.{environment}.json files no longer need to repeat the whole configuration now; rather, they can make targeted overrides of just the things they want to customize.
- Extensive documentation update in the user's guide, to capture the way the configuration system works.