### PR TITLE
Fix CWD case independence bug

### DIFF
--- a/src/Mdfmt/Processor.cs
+++ b/src/Mdfmt/Processor.cs
@@ -30,7 +30,7 @@ internal class Processor
     /// Each key, with stale information, maps to the new updated heading text.  The purpose of this
     /// data structure is to drive cross-document link updating.
     /// </summary>
-    private readonly Dictionary<string, string> _staleCpathFragmentToUpdatedHeadingText = [];
+    private readonly Dictionary<string, string> _staleCpathFragmentToUpdatedHeadingText = new([], StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// This is a set of keys like the ones that occur in the <c>_staleCpathFragmentToUpdatedHeadingText</c>
@@ -41,7 +41,7 @@ internal class Processor
     /// must investigate manually.  With well-structured Markdown, this kind of ambiguity won't occur,
     /// but we have to be prepared for it.
     /// </summary>
-    private readonly HashSet<string> _ambiguousStaleCpathFragments = [];
+    private readonly HashSet<string> _ambiguousStaleCpathFragments = new([], StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// One of each different kind of link destination generator.

--- a/src/Mdfmt/Program.cs
+++ b/src/Mdfmt/Program.cs
@@ -14,7 +14,7 @@ namespace Mdfmt;
 
 internal class Program
 {
-    public const string Version = "1.5";
+    public const string Version = "v1.5.1";
 
     public static void Main(string[] args)
     {


### PR DESCRIPTION
Fix bug where cwd was not treated as case-independent when tracking heading changes and applying cross-document link updates.  This fix leads to the patch version v1.5.1.