### PR TITLE
Remove the "v" from the version number

### DIFF
--- a/src/Mdfmt/Program.cs
+++ b/src/Mdfmt/Program.cs
@@ -14,7 +14,7 @@ namespace Mdfmt;
 
 internal class Program
 {
-    public const string Version = "v1.5.1";
+    public const string Version = "1.5.1";
 
     public static void Main(string[] args)
     {


### PR DESCRIPTION
Remove the "v" from the version number for now, as it breaks release script